### PR TITLE
Fix memory leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,16 @@
 'use strict';
 const symbolEnd = Symbol('pForever.end');
 
-module.exports = function loop(fn, prevVal) {
-	return Promise.resolve(prevVal).then(fn).then(x => x !== symbolEnd && loop(fn, x));
+module.exports = function (fn, initVal) {
+	return new Promise((resolve, reject) => {
+		const loop = prevVal => Promise.resolve(prevVal).then(fn).then(lastVal => {
+			if (lastVal === symbolEnd) {
+				return resolve();
+			}
+			loop(lastVal);
+		}).catch(reject);
+		loop(initVal);
+	});
 };
 
 module.exports.end = symbolEnd;


### PR DESCRIPTION
By returning the result of `&& loop(fn, x)` recursively a memory leak is created. Each recursion creates a scope that is never GC'ed in Node 4 and 6. This is not the case in Node 8. The V8 GC I presume has gotten smarter.

The following code crashes with `JavaScript heap out of memory` on my machine after about 30 seconds.

```js
pForever(() => Promise.resolve());
```

With the PR implementation no value is returned within the loop. This allows the older V8 GC to clean up each scope. I didn't test other engines though. We might want to do that.

At least this fixes the out-of-memory on V8 prior to Node 8.

The tests are fine. One minor change is that an ended `pForever` now resolves with `undefined` instead of `false`.
